### PR TITLE
feat: allow copying prompt to clipboard as an alternative to calling OpenAI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ python-dotenv
 openai
 gitpython
 PyGithub
+pyperclip

--- a/src/service/terminal_service.py
+++ b/src/service/terminal_service.py
@@ -38,17 +38,37 @@ class TerminalService:
             termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
         return key
 
+    def get_user_choice(self, prompt, choices):
+        """
+        Prompt the user to select from a list of choices.
+
+        :param prompt: The prompt label to display.
+        :param choices: A dictionary where keys are valid inputs, and values are descriptions.
+        :return: The key corresponding to the user's choice.
+        """
+        while True:
+            self.print(f"{prompt}")
+            for key, description in choices.items():
+                self.print(color_text(f"{key}: {description}", '34'))
+            self.print("\nChoose an option:")
+            key = self.get_single_keypress()
+            self.clear()
+
+            if key in choices:
+                return key
+            else:
+                self.print(f"Invalid choice '{key}'. Please try again.")
+
     def get_user_input(self, label, default_value):
         """Prompt user for input with a single key press to open an editor."""
-        terminal_manager = TerminalService()
         while True:
             # Color the default value text (color code 34 = blue)
             colored_default_value = color_text(default_value, "34")
-            terminal_manager.print(f"{label}:\n{colored_default_value}")
-            terminal_manager.print("Press 'e' to edit, 'x' to exit, or any other key to confirm.")
+            self.print(f"\n{label}:\n{colored_default_value}")
+            self.print("\nPress 'e' to edit, 'x' to exit, or any other key to confirm.")
 
             key = self.get_single_keypress()  # Capture single key press
-            terminal_manager.clear()  # Clear all dynamically printed lines
+            self.clear()  # Clear all dynamically printed lines
 
             if key.lower() == "x":  # Check if the key is 'x' (case-insensitive)
                 print("Bye!")
@@ -74,3 +94,34 @@ class TerminalService:
                         os.remove(temp_path)
             else:
                 return default_value
+
+    def get_direct_user_input(self, description):
+        """Prompt user for input with a single key press to open an editor."""
+        while True:
+            self.print(f"{color_text(description, '34')}")
+            self.print("Press 'x' to exit, or any other key to continue.")
+
+            key = self.get_single_keypress()  # Capture single key press
+            self.clear()
+
+            if key.lower() == "x":
+                print("Bye!")
+                sys.exit(0)  # Exit the program
+            else:
+                editor = os.getenv("EDITOR", "vi")
+                with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as temp_file:
+                    temp_file.flush()
+                    temp_path = temp_file.name
+
+                try:
+                    result = subprocess.run([editor, temp_path], check=False)
+                    if result.returncode != 0:
+                        print("Editor exited without saving. Exiting.")
+                        sys.exit(0)
+                    with open(temp_path, "r") as temp_file:
+                        edited_value = temp_file.read().strip()
+                    os.remove(temp_path)
+                    return edited_value
+                finally:
+                    if os.path.exists(temp_path):
+                        os.remove(temp_path)


### PR DESCRIPTION
## Description
This pull request adds functionality to copy the combined prompt to the clipboard as an alternative to calling the OpenAI API. This feature is aimed at users who prefer to use their own AI models for processing the prompt.

## Changes
- Modified `git_change_manager.py` to add user choices for copying the prompt to the clipboard or calling OpenAI.
- Enhanced `TerminalService` to include methods for handling user choices and direct user input via the terminal.
- Updated the logic to handle responses based on the selected user choice.

## Motivation and Context
This change provides flexibility for users by allowing them to use their own AI models instead of relying solely on OpenAI. It improves usability and expands the potential user base for ai-git-tools.

## Checklist
- [x] I have tested the changes locally.
- [ ] Documentation has been updated if necessary.
- [x] This PR is ready for review.