### PR TITLE
feat: upload coverage to Coveralls and add badge to README

### DIFF
--- a/.github/workflows/test-and-coverage.yml
+++ b/.github/workflows/test-and-coverage.yml
@@ -25,12 +25,21 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r dev-requirements.txt
+          pip install coveralls
 
       - name: Run Tests and Coverage
         run: |
           pytest --cov=src --cov-report=xml --cov-fail-under=85
 
-      - name: Upload Coverage Report
+      - name: Upload coverage to Coveralls
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        run: |
+          coverage run --source=src -m pytest tests/
+          coverage report --fail-under=85
+          coveralls
+
+      - name: Upload Coverage Report Artifact
         uses: actions/upload-artifact@v4
         with:
           name: coverage-report

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ run:
 	./dist/ai-git-tools
 
 clean:
-	rm -rf build dist __pycache__ *.spec
+	rm -rf build dist __pycache__ *.spec htmlcov
 	find . -name "*.pyc" -delete
 	find . -name "__pycache__" -type d -exec rm -r {} +
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Coverage Status](https://coveralls.io/repos/github/rodrigoluizs/ai-git-tools/badge.svg?branch=main)](https://coveralls.io/github/rodrigoluizs/ai-git-tools?branch=main)
 # AI Git Tools
 
 The `ai-git-tools` command-line tool leverages the power of AI to streamline your Git workflow. By analyzing your code changes, it automates the creation of intelligent commit messages, branch names, and pull requests, saving you time and ensuring consistency.


### PR DESCRIPTION
## Description
Upload test coverage data to Coveralls and integrate a badge into the README for coverage visibility.

## Changes
- Updated GitHub Actions workflow to include Coveralls upload step.
- Modified `Makefile` to clean up coverage directories.
- Added Coveralls badge to README.

## Motivation and Context
This change ensures test coverage metrics are uploaded to Coveralls for better visibility and tracking. The badge in the README provides an at-a-glance view of the project's coverage status.

## Checklist
- [x] I have tested the changes locally.
- [ ] Documentation has been updated if necessary.
- [x] This PR is ready for review.