### PR TITLE
refactor: rename binaries and documentation references to agt

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,11 +37,11 @@ jobs:
         shell: bash
         run: |
           if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
-            mv dist/main dist/ai-git-tools-linux
+            mv dist/main dist/agt-linux
           elif [ "${{ matrix.os }}" = "macos-latest" ]; then
-            mv dist/main dist/ai-git-tools-macos
+            mv dist/main dist/agt-macos
           elif [ "${{ matrix.os }}" = "windows-latest" ]; then
-            mv dist/main.exe dist/ai-git-tools-win.exe
+            mv dist/main.exe dist/agt-win.exe
           fi
 
       - name: Release
@@ -52,6 +52,6 @@ jobs:
           draft: false
           prerelease: false
           files: |
-            dist/ai-git-tools-linux
-            dist/ai-git-tools-macos
-            dist/ai-git-tools-win.exe
+            dist/agt-linux
+            dist/agt-macos
+            dist/agt-win.exe

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ dev: .venv
 build:
 	pip install pyinstaller
 	pyinstaller --onefile --add-data "resources:resources" src/main.py
-	mv dist/main dist/ai-git-tools
+	mv dist/main dist/agt
 
 test:
 	pytest --cov=src --cov-fail-under=93 -vv
@@ -27,7 +27,7 @@ coverage:
 	open $(COV_REPORT_DIR)/index.html
 
 run:
-	./dist/ai-git-tools
+	./dist/agt
 
 clean:
 	rm -rf build dist __pycache__ *.spec htmlcov

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/rodrigoluizs/ai-git-tools/badge.svg?branch=main)](https://coveralls.io/github/rodrigoluizs/ai-git-tools?branch=main)
 # AI Git Tools
 
-The `ai-git-tools` command-line tool leverages the power of AI to streamline your Git workflow. By analyzing your code changes, it automates the creation of intelligent commit messages, branch names, and pull requests, saving you time and ensuring consistency.
+The `agt` command-line tool leverages the power of AI to streamline your Git workflow. By analyzing your code changes, it automates the creation of intelligent commit messages, branch names, and pull requests, saving you time and ensuring consistency.
 
 ## Features
 
@@ -43,20 +43,20 @@ Download the latest release for your platform from the [GitHub Releases page](ht
 
 On Linux/MacOS, make the binary executable:
 ```bash
-chmod +x ai-git-tools
+chmod +x agt
 ```
 
 ## Usage
 
 Run the tool directly from the command line:
 ```bash
-ai-git-tools
+agt
 ```
 
 ### Help
 To display help documentation:
 ```bash
-ai-git-tools --help
+agt --help
 ```
 
 ## Requirements

--- a/src/main.py
+++ b/src/main.py
@@ -13,7 +13,7 @@ def display_help():
     AI Git Tools - Command Line Tool
 
     Usage:
-      ai-git-tools [options]
+      agt [options]
 
     Description:
       AI-powered Git tools for automating common Git tasks like generating GitHub pull requests.
@@ -22,7 +22,7 @@ def display_help():
       -h, --help      Show this help message and exit.
 
     Examples:
-      ai-git-tools      Automatically create a GitHub pull request using code changes.
+      agt      Automatically create a GitHub pull request using code changes.
     """
     print(help_text)
 
@@ -32,7 +32,7 @@ def main():
     Main entry point for the command-line tool.
     """
     parser = argparse.ArgumentParser(
-        description="AI Git Tools - Command Line Tool", usage="ai-git-tools [options]", add_help=False
+        description="AI Git Tools - Command Line Tool", usage="agt [options]", add_help=False
     )
 
     parser.add_argument("-h", "--help", action="store_true", help="Show this help message and exit.")


### PR DESCRIPTION
## Description
Rename binaries and documentation references from `ai-git-tools` to `agt` for simplicity and consistency across the project.

## Changes
- Updated binary names in the release workflow (`.github/workflows/release.yml`).
- Updated references in the `Makefile`.
- Adjusted the README to reflect the new binary name and usage examples.
- Updated the command-line tool name in `src/main.py` help and usage sections.

## Motivation and Context
Simplifying the name to `agt` makes it shorter and easier to use, improving usability and readability across the project.

## Checklist
- [x] I have tested the changes locally.
- [x] Documentation has been updated if necessary.
- [x] This PR is ready for review.