### PR TITLE
feat: add support for Bitbucket integration in git change manager

### DIFF
--- a/.github/workflows/test-and-coverage.yml
+++ b/.github/workflows/test-and-coverage.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Run Tests and Coverage
         run: |
-          pytest --cov=src --cov-report=xml --cov-fail-under=93
+          pytest --cov=src --cov-report=xml --cov-fail-under=94
 
       - name: Upload coverage to Coveralls
         env:

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ build:
 	mv dist/main dist/agt
 
 test:
-	pytest --cov=src --cov-fail-under=93 -vv
+	pytest --cov=src --cov-fail-under=94 -vv
 
 coverage:
 	pytest --cov=src --cov-report=term --cov-report=html:$(COV_REPORT_DIR) -vv

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The `agt` command-line tool leverages the power of AI to streamline your Git wor
 - **Branch Naming**: Automatically generate branch names based on conventional commit guidelines.
 - **Commit Messages**: Create consistent and meaningful commit messages powered by AI.
 - **Pull Request Creation**: Generate and open GitHub pull requests directly from your terminal.
-- **Multi-Service Support**: Currently supporting only GitHub, other service providers will come soon.
+- **Multi-Service Support**: Currently supporting GitHub and Bitbucket, other service providers will come soon.
 
 ## How It Works
 
@@ -69,7 +69,11 @@ agt --help
 Set up your environment variables:
 
 - `OPENAI_API_KEY`: Your OpenAI API key.
-- `GITHUB_TOKEN`: Your GitHub personal access token.
+- For GitHub Repos
+  - `GITHUB_TOKEN`: Your GitHub personal access token.
+- For Bitbucket Repos
+  - `BITBUCKET_USERNAME`: Your Bitbucket username.
+  - `BITBUCKET_APP_PASSWORD`: An app password with permissions to create commits and pull requests.
 
 ## Contributing
 

--- a/scripts/check_coverage.sh
+++ b/scripts/check_coverage.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-pytest --cov=src --cov-fail-under=93
+pytest --cov=src --cov-fail-under=94

--- a/src/core/git_change_manager.py
+++ b/src/core/git_change_manager.py
@@ -4,6 +4,7 @@ import sys
 
 import pyperclip
 from git import Repo, InvalidGitRepositoryError
+from src.service.bitbucket_service import BitbucketService
 from src.service.git_service import GitService
 from src.service.github_service import GitHubService
 from src.service.openai_service import call_openai_api
@@ -70,8 +71,7 @@ def get_service_provider() -> VcsService:
             print(f"Unsupported service provider: {remote_url}")
             sys.exit(0)
         elif "bitbucket.org" in remote_url:
-            print(f"Unsupported service provider: {remote_url}")
-            sys.exit(0)
+            return BitbucketService()
         else:
             print(f"Unsupported service provider: {remote_url}")
             sys.exit(0)

--- a/src/service/bitbucket_service.py
+++ b/src/service/bitbucket_service.py
@@ -53,17 +53,9 @@ class BitbucketService(VcsService):
         data = {
             "title": pr_title,
             "description": pr_body,
-            "source": {
-                "branch": {
-                    "name": head_branch
-                }
-            },
-            "destination": {
-                "branch": {
-                    "name": base_branch
-                }
-            },
-            "close_source_branch": True
+            "source": {"branch": {"name": head_branch}},
+            "destination": {"branch": {"name": base_branch}},
+            "close_source_branch": True,
         }
 
         return data
@@ -91,11 +83,7 @@ class BitbucketService(VcsService):
             data = self.build_pull_request_data(head_branch, base_branch, pr_title, pr_body)
 
             # Send the POST request to create the pull request
-            response = requests.post(
-                repo_url,
-                json=data,
-                auth=(self.username, self.password)
-            )
+            response = requests.post(repo_url, json=data, auth=(self.username, self.password))
 
             # Raise an exception for HTTP errors
             response.raise_for_status()
@@ -110,5 +98,5 @@ class BitbucketService(VcsService):
             sys.exit(1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     print(BitbucketService().get_username())

--- a/src/service/bitbucket_service.py
+++ b/src/service/bitbucket_service.py
@@ -1,0 +1,114 @@
+import os
+import sys
+
+import requests
+from src.service.git_service import GitService
+from src.service.vcs_service import VcsService
+
+
+class BitbucketService(VcsService):
+    git: GitService
+
+    def __init__(self):
+        super().__init__()
+
+        self.git = GitService()
+        self.api_url = "https://api.bitbucket.org/2.0"
+        self.username = os.getenv("BITBUCKET_USERNAME")
+        self.password = os.getenv("BITBUCKET_APP_PASSWORD")
+
+    def validate_environment(self):
+        """Ensure BITBUCKET_USERNAME and BITBUCKET_APP_PASSWORD are set."""
+        if not os.getenv("BITBUCKET_USERNAME") or not os.getenv("BITBUCKET_APP_PASSWORD"):
+            print("Error: BITBUCKET_USERNAME and BITBUCKET_APP_PASSWORD environment variables are not set.")
+            sys.exit(1)
+
+    def get_username(self):
+        """
+        Retrieve the current authenticated username from Bitbucket Cloud.
+        """
+        try:
+            response = requests.get(
+                f"{self.api_url}/user",
+                auth=(self.username, self.password),
+            )
+            response.raise_for_status()  # Raise an exception for HTTP errors
+            user_data = response.json()
+            return user_data.get("username")
+        except requests.exceptions.RequestException as e:
+            print(f"Error fetching Bitbucket username: {e}")
+            sys.exit(1)
+
+    @staticmethod
+    def build_pull_request_data(head_branch, base_branch, pr_title, pr_body):
+        """
+        Build the data object for creating a pull request on Bitbucket.
+
+        :param head_branch: The source branch for the pull request.
+        :param base_branch: The target branch for the pull request.
+        :param pr_title: The title of the pull request.
+        :param pr_body: The description of the pull request.
+        :return: A dictionary containing the PR data.
+        """
+        data = {
+            "title": pr_title,
+            "description": pr_body,
+            "source": {
+                "branch": {
+                    "name": head_branch
+                }
+            },
+            "destination": {
+                "branch": {
+                    "name": base_branch
+                }
+            },
+            "close_source_branch": True
+        }
+
+        return data
+
+    def create_pull_request(self, head_branch, pr_title, pr_body):
+        """
+        Create a pull request on Bitbucket using requests.
+
+        :param head_branch: The branch to merge from.
+        :param pr_title: The title of the pull request.
+        :param pr_body: The description of the pull request.
+        :return: The URL of the created pull request.
+        """
+        try:
+            # Use GitService to get repo details
+            git = GitService()
+            repo_slug = git.get_repo_name()
+            base_branch = git.find_parent_branch()
+
+            # Build the URL for the repository
+            project_key, repo_name = repo_slug.split("/")
+            repo_url = f"{self.api_url}/repositories/{project_key}/{repo_name}/pullrequests"
+
+            # Build the payload
+            data = self.build_pull_request_data(head_branch, base_branch, pr_title, pr_body)
+
+            # Send the POST request to create the pull request
+            response = requests.post(
+                repo_url,
+                json=data,
+                auth=(self.username, self.password)
+            )
+
+            # Raise an exception for HTTP errors
+            response.raise_for_status()
+
+            # Extract the PR URL
+            pr_url = response.json().get("links", {}).get("html", {}).get("href", "Pull request URL not available.")
+
+            return pr_url
+
+        except requests.exceptions.RequestException as e:
+            print(f"Failed to create pull request: {e}")
+            sys.exit(1)
+
+
+if __name__ == '__main__':
+    print(BitbucketService().get_username())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,3 +6,5 @@ def set_env_vars(monkeypatch):
     """Automatically set environment variables for all tests."""
     monkeypatch.setenv("GITHUB_TOKEN", "fake-token")
     monkeypatch.setenv("OPENAI_API_KEY", "fake-key")
+    monkeypatch.setenv("BITBUCKET_USERNAME", "fake-key")
+    monkeypatch.setenv("BITBUCKET_APP_PASSWORD", "fake-key")

--- a/tests/core/test_git_change_manager.py
+++ b/tests/core/test_git_change_manager.py
@@ -3,6 +3,7 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 from git import InvalidGitRepositoryError
+from src.service.bitbucket_service import BitbucketService
 from src.core.git_change_manager import get_prompt_file, get_service_provider, print_colored_summary, validate_env_vars
 from src.core.git_change_manager import main
 from src.service.github_service import GitHubService
@@ -108,8 +109,8 @@ def test_get_service_provider_bitbucket(mock_repo):
 
     mock_repo.remote.return_value.urls = iter(["https://bitbucket.org/test/repo"])
 
-    with pytest.raises(SystemExit):
-        get_service_provider()
+    service = get_service_provider()
+    assert isinstance(service, BitbucketService)
 
 
 @patch("src.core.git_change_manager.Repo")

--- a/tests/service/test_bitbucket_service.py
+++ b/tests/service/test_bitbucket_service.py
@@ -1,0 +1,111 @@
+import os
+import unittest
+from unittest.mock import patch, MagicMock
+
+import requests
+from src.service.bitbucket_service import BitbucketService
+
+
+class TestBitbucketService(unittest.TestCase):
+    def setUp(self):
+        self.service = BitbucketService()
+        self.service.username = "test_user"
+        self.service.password = "test_password"
+        self.service.api_url = "https://api.bitbucket.org/2.0"
+
+    @patch.dict(os.environ, {"BITBUCKET_USERNAME": "test_user", "BITBUCKET_APP_PASSWORD": "test_password"})
+    def test_validate_environment(self):
+        # Ensure the method does not raise an exception when the environment is valid
+        try:
+            self.service.validate_environment()
+        except SystemExit:
+            self.fail("validate_environment raised SystemExit unexpectedly!")
+
+    @patch.dict(os.environ, {"BITBUCKET_USERNAME": '', "BITBUCKET_APP_PASSWORD": ''})
+    def test_validate_environment_missing_env_vars(self):
+        # Ensure the method exits when the environment variables are missing
+        with self.assertRaises(SystemExit):
+            self.service.validate_environment()
+
+    @patch("requests.get")
+    def test_get_username_success(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"username": "test_user"}
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        username = self.service.get_username()
+        self.assertEqual(username, "test_user")
+        mock_get.assert_called_once_with(
+            f"{self.service.api_url}/user",
+            auth=(self.service.username, self.service.password),
+        )
+
+    @patch("requests.get")
+    def test_get_username_failure(self, mock_get):
+        mock_get.side_effect = requests.exceptions.RequestException("Error fetching username")
+
+        with self.assertRaises(SystemExit):
+            self.service.get_username()
+
+    def test_build_pull_request_data(self):
+        head_branch = "feature/test"
+        base_branch = "main"
+        pr_title = "Test PR"
+        pr_body = "This is a test PR."
+        data = self.service.build_pull_request_data(head_branch, base_branch, pr_title, pr_body)
+
+        expected_data = {
+            "title": pr_title,
+            "description": pr_body,
+            "source": {"branch": {"name": head_branch}},
+            "destination": {"branch": {"name": base_branch}},
+            "close_source_branch": True,
+        }
+        self.assertEqual(data, expected_data)
+
+    @patch("requests.post")
+    @patch("src.service.git_service.GitService.get_repo_name", return_value="test_project/test_repo")
+    @patch("src.service.git_service.GitService.find_parent_branch", return_value="main")
+    def test_create_pull_request_success(self, mock_find_branch, mock_get_repo, mock_post):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "links": {"html": {"href": "https://bitbucket.org/test_project/test_repo/pull-requests/1"}}
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        pr_url = self.service.create_pull_request(
+            head_branch="feature/test",
+            pr_title="Test PR",
+            pr_body="This is a test pull request."
+        )
+        self.assertEqual(pr_url, "https://bitbucket.org/test_project/test_repo/pull-requests/1")
+
+        mock_post.assert_called_once_with(
+            f"{self.service.api_url}/repositories/test_project/test_repo/pullrequests",
+            json={
+                "title": "Test PR",
+                "description": "This is a test pull request.",
+                "source": {"branch": {"name": "feature/test"}},
+                "destination": {"branch": {"name": "main"}},
+                "close_source_branch": True,
+            },
+            auth=(self.service.username, self.service.password),
+        )
+
+    @patch("requests.post")
+    @patch("src.service.git_service.GitService.get_repo_name", return_value="test_project/test_repo")
+    @patch("src.service.git_service.GitService.find_parent_branch", return_value="main")
+    def test_create_pull_request_failure(self, mock_find_branch, mock_get_repo, mock_post):
+        mock_post.side_effect = requests.exceptions.RequestException("Error creating PR")
+
+        with self.assertRaises(SystemExit):
+            self.service.create_pull_request(
+                head_branch="feature/test",
+                pr_title="Test PR",
+                pr_body="This is a test pull request."
+            )
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/service/test_bitbucket_service.py
+++ b/tests/service/test_bitbucket_service.py
@@ -21,7 +21,7 @@ class TestBitbucketService(unittest.TestCase):
         except SystemExit:
             self.fail("validate_environment raised SystemExit unexpectedly!")
 
-    @patch.dict(os.environ, {"BITBUCKET_USERNAME": '', "BITBUCKET_APP_PASSWORD": ''})
+    @patch.dict(os.environ, {"BITBUCKET_USERNAME": "", "BITBUCKET_APP_PASSWORD": ""})
     def test_validate_environment_missing_env_vars(self):
         # Ensure the method exits when the environment variables are missing
         with self.assertRaises(SystemExit):
@@ -76,9 +76,7 @@ class TestBitbucketService(unittest.TestCase):
         mock_post.return_value = mock_response
 
         pr_url = self.service.create_pull_request(
-            head_branch="feature/test",
-            pr_title="Test PR",
-            pr_body="This is a test pull request."
+            head_branch="feature/test", pr_title="Test PR", pr_body="This is a test pull request."
         )
         self.assertEqual(pr_url, "https://bitbucket.org/test_project/test_repo/pull-requests/1")
 
@@ -102,10 +100,9 @@ class TestBitbucketService(unittest.TestCase):
 
         with self.assertRaises(SystemExit):
             self.service.create_pull_request(
-                head_branch="feature/test",
-                pr_title="Test PR",
-                pr_body="This is a test pull request."
+                head_branch="feature/test", pr_title="Test PR", pr_body="This is a test pull request."
             )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Description
This update introduces support for Bitbucket integration in the git change manager. It allows users to work with repositories hosted on Bitbucket, expanding the tool's functionality.

## Changes
- Introduced the `BitbucketService` class to handle Bitbucket-specific API interactions.
- Modified `get_service_provider` logic to include Bitbucket as a supported VCS provider.
- Validated environment variables for Bitbucket credentials (username and app password).
- Added unit tests for the new `BitbucketService` class.
- Updated test coverage threshold from 93% to 94% across all test-related configurations.
- Enhanced tests to validate Bitbucket functionality.

## Motivation and Context
These changes were made to expand the usability of the git change manager by supporting an additional VCS platform, thereby catering to a broader audience of developers.

## Checklist
- [ ] I have tested the changes locally.
- [ ] Documentation has been updated if necessary.
- [ ] This PR is ready for review.