### PR TITLE
fix: use parent branch when calculating the git diff

### DIFF
--- a/src/service/git_service.py
+++ b/src/service/git_service.py
@@ -70,7 +70,14 @@ class GitService:
         try:
             unstaged = self.repo.git.diff()
             staged = self.repo.git.diff(cached=True)
-            branch = self.repo.git.diff("main...HEAD")
+
+            parent_branch = self.find_parent_branch()
+
+            if not parent_branch:
+                print("Unable to determine the parent branch. Defaulting to 'main'.")
+                parent_branch = "main"
+
+            branch = self.repo.git.diff(f"{parent_branch}...HEAD")
 
             # Get untracked files and their content
             untracked_content = ""


### PR DESCRIPTION
## Description
Provide a brief description of the changes in this pull request. What problem does it solve or what feature does it add?

## Changes
- Changed the git diff calculation to use the parent branch over the main branch by default.
- Added logic to determine the parent branch dynamically and fall back to 'main' if the parent cannot be determined.

## Motivation and Context
These changes were made to ensure that the git diff calculation is more accurate and reflects the correct branch context rather than always defaulting to 'main'.

## Checklist
- [x] I have tested the changes locally.
- [ ] Documentation has been updated if necessary.
- [x] This PR is ready for review.