### PR TITLE
fix: update PR template comment handling

### DIFF
--- a/resources/prompts/git-change-manager.txt
+++ b/resources/prompts/git-change-manager.txt
@@ -31,8 +31,8 @@ constraints:
 ## Issue Reference
 Closes # <!-- *add the issue number if applicable* -->
 
-5. in the pr body template, the content within '<!--' and  '-->' represents the template itself, when you create the PR body the final text should not be within '<!--' and  '-->' otherwise it will not appear in the Github UI
-6. if I don't mention that it closes a specific issue, omit the Issue Reference section
+5. In the PR body template, do not return any text that appears within `<!--` and `-->` in the original template. Replace these placeholders with meaningful content.
+6. If I don't mention that it closes a specific issue, omit the "Issue Reference" section entirely from the output.
 
 Please provide the following output in JSON format with these keys:
 {


### PR DESCRIPTION
## Description
Improved the instructions for handling comments in the PR body template to ensure text within comment tags is appropriately excluded in the final output.

## Changes
- Updated the instructions in `git-change-manager.txt` to clarify that text within comment tags in the PR body template should not appear in the final output.

## Motivation and Context
These changes were made to help developers ensure the PR body template displays correctly in the GitHub UI without including comment syntax.

## Checklist
- [x] I have tested the changes locally.
- [x] Documentation has been updated if necessary.
- [x] This PR is ready for review.